### PR TITLE
Update returned file download path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changlog
+
+## v0.1.4 22 September 2016
+
+  - Expected Tracepart API change at the end of October 2016, will deprecate
+    multiple CAD file support in download links & instead will return archive
+    link for every available file.

--- a/lib/traceparts/client.rb
+++ b/lib/traceparts/client.rb
@@ -72,7 +72,7 @@ module Traceparts
 
       json = JSON.parse(response.body)
 
-      json[1][1][1]
+      json[1][0][1]
     end
 
     def part(classification_id, part_number, user_email)


### PR DESCRIPTION
Tracepart API is going to be deprecate supported multiple download
paths and will use archives intead.
- Prepare Tracepart API client for expected changes.
